### PR TITLE
Replace `url()` with `path()` for Django 4.2

### DIFF
--- a/cron/urls.py
+++ b/cron/urls.py
@@ -1,8 +1,10 @@
-from django.conf.urls import url
+from django.urls import path
+
 from cron.views import process_frequently, process_hourly, process_daily
 
+
 urlpatterns = [
-    url(r'^frequently/$', process_frequently, name='frequently'),
-    url(r'^hourly/$', process_hourly, name='hourly'),
-    url(r'^daily/$', process_daily, name='daily'),
+    path('frequently/', process_frequently, name='frequently'),
+    path('hourly/', process_hourly, name='hourly'),
+    path('daily/', process_daily, name='daily'),
 ]


### PR DESCRIPTION
Updating `urls.py` for Django 4.2+